### PR TITLE
Revert "Added option to use MulticallProvider instead of StaticJsonRpcProvider when using custom provider"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# NestJS-Ethers
+NestJS-Ethers
+=============
 
 [![npm](https://img.shields.io/npm/v/nestjs-ethers)](https://www.npmjs.com/package/nestjs-ethers)
 [![CircleCI](https://circleci.com/gh/blockcoders/nestjs-ethers/tree/main.svg?style=svg)](https://circleci.com/gh/blockcoders/nestjs-ethers/tree/main)
@@ -6,6 +7,7 @@
 [![vulnerabilities](https://badgen.net/snyk/blockcoders/nestjs-ethers)](https://snyk.io/test/github/blockcoders/nestjs-ethers)
 [![CodeQL](https://github.com/blockcoders/nestjs-ethers/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/blockcoders/nestjs-ethers/actions/workflows/codeql-analysis.yml)
 [![supported platforms](https://img.shields.io/badge/platforms-Express%20%26%20Fastify-green)](https://img.shields.io/badge/platforms-Express%20%26%20Fastify-green)
+
 
 Ethereum utilities for NestJS based on [Ethers.js](https://github.com/ethers-io/ethers.js/)
 
@@ -31,7 +33,7 @@ import { EthersModule } from 'nestjs-ethers';
 class MyModule {}
 ```
 
-**NOTE:** _By default `EthersModule` will try to connect using [getDefaultProvider](https://docs.ethers.io/v5/api/providers/#providers-getDefaultProvider). It's the safest, easiest way to begin developing on Ethereum. It creates a [FallbackProvider](https://docs.ethers.io/v5/api/providers/other/#FallbackProvider) connected to as many backend services as possible._
+**NOTE:** *By default `EthersModule` will try to connect using [getDefaultProvider](https://docs.ethers.io/v5/api/providers/#providers-getDefaultProvider). It's the safest, easiest way to begin developing on Ethereum. It creates a [FallbackProvider](https://docs.ethers.io/v5/api/providers/other/#FallbackProvider) connected to as many backend services as possible.* 
 
 ### Configuration params
 
@@ -47,60 +49,60 @@ interface EthersModuleOptions {
    * such as http://localhost:8545 or wss://example.com.
    * @see {@link https://docs.ethers.io/v5/api/providers/types/#providers-Networkish}
    */
-  network?: Network | string
+  network?: Network | string;
 
   /**
    * Optional parameter for Alchemy API Token
    * @see {@link https://alchemyapi.io}
    */
-  alchemy?: string
+  alchemy?: string;
 
   /**
    * Optional parameter for Etherscan API Token
    * @see {@link https://etherscan.io}
    */
-  etherscan?: string
-
+  etherscan?: string;
+  
   /**
    * Optional parameter for Bscscan API Token
    * @see {@link https://bscscan.com/}
    */
-  bscscan?: string
+  bscscan?: string;
 
   /**
    * Optional parameter for use Cloudflare Provider
    * @see {@link https://cloudflare-eth.com}
    */
-  cloudflare?: boolean
+  cloudflare?: boolean;
 
   /**
    * Optional parameter for Infura Project ID
    * or InfuraProviderOptions(applicationId, applicationSecretKey)
    * @see {@link https://infura.io}
    */
-  infura?: InfuraProviderOptions | string
+  infura?: InfuraProviderOptions | string;
 
   /**
    * Optional parameter for Pocket Network Application ID
    * or PocketProviderOptions(projectId, projectSecret)
    * @see {@link https://pokt.network}
    */
-  pocket?: PocketProviderOptions | string
-
+  pocket?: PocketProviderOptions | string;
+  
   /**
    * Optional parameter for Moralis API Token
    * or MoralisProviderOptions(apiKey, region)
    * @see {@link https://moralis.io/}
    */
-  moralis?: MoralisProviderOptions | string
-
+  moralis?: MoralisProviderOptions | string;
+  
   /**
    * Optional parameter for Ankr API Token
    * or AnkrProviderOptions(apiKey, projectSecret)
    * @see {@link https://www.ankr.com/}
    */
-  ankr?: AnkrProviderOptions | string
-
+  ankr?: AnkrProviderOptions | string;
+  
   /**
    * Optional parameter for a custom StaticJsonRpcProvider
    * You can connect using an URL, ConnectionInfo or an array of both.
@@ -110,48 +112,38 @@ interface EthersModuleOptions {
   custom?: ConnectionInfo | string | (ConnectionInfo | string)[]
 
   /**
-   * Optional parameter to use MulticallProvider
-   * Will create a MulticallProvider instance using StaticJsonRpcProvider when using custom provider.
-   * @see {@link https://www.npmjs.com/package/@0xsequence/multicall}
-   *
-   * Check if is sequence multicall contract is deployed on a network.
-   * @see {@link https://blockscan.com/address/0xd130B43062D875a4B7aF3f8fc036Bc6e9D3E1B3E}
-   */
-  batched?: boolean
-
-  /**
    * Optional parameter the number of backends that must agree
    * (default: 2 for mainnet, 1 for testnets)
    */
-  quorum?: number
+  quorum?: number;
 
   /**
    * Optional parameter if this option is false, EthersModule won't wait until
-   * the providers are ready. If this option is true, EthersModule  will wait
+   * the providers are ready. If this option is true, EthersModule  will wait 
    * until the network has heen established for all the providers.
    * @see {@link https://docs.ethers.io/v5/api/providers/provider/#Provider-ready}
    */
-  waitUntilIsConnected?: boolean
+  waitUntilIsConnected?: boolean;
 
   /**
    * Optional parameter if this option is false, EthersModule will try to connect
    * with the credentials provided in options. If you define more than one provider,
    * EthersModule will use the FallbackProvider to send multiple requests simultaneously.
    */
-  useDefaultProvider?: boolean
+  useDefaultProvider?: boolean;
 
   /**
-   * Optional parameter if this option is true, EthersModule will disable
+   * Optional parameter if this option is true, EthersModule will disable 
    * the console.log in the ethers.js library.
    */
   disableEthersLogger?: boolean
-
+  
   /**
    * Optional parameter to associate a token name to EthersProvider,
    * the token is used to request an instance of a class by the same name.
    * This can be useful when you want multiple intances of EthersProvider.
    */
-  token?: string
+  token?: string;
 }
 ```
 
@@ -234,14 +226,14 @@ class TestModule {}
 Or you can just pass `ConfigService` to `providers`, if you don't have any `ConfigModule`:
 
 ```ts
-import { EthersModule, RINKEBY_NETWORK } from 'nestjs-ethers'
+import { EthersModule, RINKEBY_NETWORK } from 'nestjs-ethers';
 
 @Injectable()
 class ConfigService {
   public readonly pocket: {
-    applicationId: '9b0afc55221c429104d04ef9'
-    applicationSecretKey: 'b5e6d6a55426712a42a93f39555973fc'
-  }
+    applicationId: '9b0afc55221c429104d04ef9',
+    applicationSecretKey: 'b5e6d6a55426712a42a93f39555973fc',
+  };
 }
 
 @Module({
@@ -254,11 +246,11 @@ class ConfigService {
           network: RINKEBY_NETWORK,
           pocket: config.pocket,
           useDefaultProvider: false,
-        }
-      },
-    }),
+        };
+      }
+    })
   ],
-  controllers: [TestController],
+  controllers: [TestController]
 })
 class TestModule {}
 ```
@@ -312,7 +304,7 @@ class TestModule {}
 `BaseProvider` implements standard [Ether.js Provider](https://docs.ethers.io/v5/api/providers/provider/). So if you are familiar with it, you are ready to go.
 
 ```ts
-import { InjectEthersProvider, BaseProvider } from 'nestjs-ethers'
+import { InjectEthersProvider, BaseProvider } from 'nestjs-ethers';
 
 @Injectable()
 export class TestService {
@@ -321,7 +313,7 @@ export class TestService {
     private readonly ethersProvider: BaseProvider,
   ) {}
   async someMethod(): Promise<Network> {
-    return this.ethersProvider.getNetwork()
+    return this.ethersProvider.getNetwork();
   }
 }
 ```
@@ -485,59 +477,14 @@ class TestController {
 }
 ```
 
-## Custom MulticallProvider
-
-If you want to use [MulticallProvider](https://www.npmjs.com/package/@0xsequence/multicall). This support any ethers.js v5 providers including but not limited to StaticJsonRpcProvider, FallbackProvider, InfuraProvider, etc.
-
-Useful when you want to reduce request time as the requests are now aggregated.
-
-```ts
-import {
-  EthersModule,
-  InjectEthersProvider,
-  BNB_TESTNET_NETWORK
-} from 'nestjs-ethers';
-
-import {
-  providers
-} from '@0xsequence/multicall';
-
-@Module({
-  imports: [
-    EthersModule.forRoot({
-      network: BNB_TESTNET_NETWORK,
-      custom: 'https://data-seed-prebsc-1-s1.binance.org:8545',
-      useDefaultProvider: false,
-      batched: true
-    })
-  ],
-  ...
-})
-class MyModule {}
-
-@Controller('/')
-class TestController {
-  constructor(
-    @InjectEthersProvider()
-    private readonly multicallProvider: providers.MulticallProvider,
-  ) {}
-  @Get()
-  async get() {
-    const gasPrice: BigNumber = await this.multicallProvider.getGasPrice()
-
-    return { gasPrice: gasPrice.toString() }
-  }
-}
-```
-
-## EthersSigner
+## EthersSigner 
 
 `EthersSigner` implements methods to create a [Wallet](https://docs.ethers.io/v5/api/signer/#Wallet) or [VoidSigner](https://docs.ethers.io/v5/api/signer/#VoidSigner). A `Signer` in ethers is an abstraction of an Ethereum Account, which can be used to sign messages and transactions and send signed transactions to the Ethereum Network. This service will also inject the `BaseProvider` into the wallet.
 
 Create a `Wallet` from a private key:
 
 ```ts
-import { EthersSigner, InjectSignerProvider, Wallet } from 'nestjs-ethers'
+import { EthersSigner, InjectSignerProvider, Wallet } from 'nestjs-ethers';
 
 @Injectable()
 export class TestService {
@@ -547,10 +494,10 @@ export class TestService {
   ) {}
   async someMethod(): Promise<string> {
     const wallet: Wallet = this.ethersSigner.createWallet(
-      '0x4c94faa2c558a998d10ee8b2b9b8eb1fbcb8a6ac5fd085c6f95535604fc1bffb',
-    )
+      '0x4c94faa2c558a998d10ee8b2b9b8eb1fbcb8a6ac5fd085c6f95535604fc1bffb'
+    );
 
-    return wallet.getAddress()
+    return wallet.getAddress();
   }
 }
 ```
@@ -558,7 +505,7 @@ export class TestService {
 Create a random [Wallet](https://docs.ethers.io/v5/api/signer/#Wallet-createRandom):
 
 ```ts
-import { EthersSigner, InjectSignerProvider, Wallet } from 'nestjs-ethers'
+import { EthersSigner, InjectSignerProvider, Wallet } from 'nestjs-ethers';
 
 @Injectable()
 export class TestService {
@@ -567,9 +514,9 @@ export class TestService {
     private readonly ethersSigner: EthersSigner,
   ) {}
   async someMethod(): Promise<string> {
-    const wallet: Wallet = this.ethersSigner.createRandomWallet()
+    const wallet: Wallet = this.ethersSigner.createRandomWallet();
 
-    return wallet.getAddress()
+    return wallet.getAddress();
   }
 }
 ```
@@ -577,7 +524,7 @@ export class TestService {
 Create a [Wallet](https://docs.ethers.io/v5/api/signer/#Wallet-fromEncryptedJson) from an encrypted JSON:
 
 ```ts
-import { EthersSigner, InjectSignerProvider, Wallet } from 'nestjs-ethers'
+import { EthersSigner, InjectSignerProvider, Wallet } from 'nestjs-ethers';
 
 @Injectable()
 export class TestService {
@@ -594,7 +541,8 @@ export class TestService {
         Crypto: {
           cipher: 'aes-128-ctr',
           cipherparams: { iv: 'bc0473d60284d2d6994bb6793e916d06' },
-          ciphertext: 'e73ed0b0c53bcaea4516a15faba3f6d76dbe71b9b46a460ed7e04a68e0867dd7',
+          ciphertext:
+            'e73ed0b0c53bcaea4516a15faba3f6d76dbe71b9b46a460ed7e04a68e0867dd7',
           kdf: 'scrypt',
           kdfparams: {
             salt: '97f0b6e17c392f76a726ceea02bac98f17265f1aa5cf8f9ad1c2b56025bc4714',
@@ -613,10 +561,10 @@ export class TestService {
           version: '0.1',
         },
       },
-      'password',
-    )
+      'password'
+    );
 
-    return wallet.getAddress()
+    return wallet.getAddress();
   }
 }
 ```
@@ -624,7 +572,7 @@ export class TestService {
 Create a [Wallet](https://docs.ethers.io/v5/api/signer/#Wallet.fromMnemonic) from a mnemonic:
 
 ```ts
-import { EthersSigner, InjectSignerProvider, Wallet } from 'nestjs-ethers'
+import { EthersSigner, InjectSignerProvider, Wallet } from 'nestjs-ethers';
 
 @Injectable()
 export class TestService {
@@ -634,10 +582,10 @@ export class TestService {
   ) {}
   async someMethod(): Promise<string> {
     const wallet: Wallet = this.ethersSigner.createWalletfromMnemonic(
-      'service basket parent alcohol fault similar survey twelve hockey cloud walk panel',
-    )
+      'service basket parent alcohol fault similar survey twelve hockey cloud walk panel'
+    );
 
-    return wallet.getAddress()
+    return wallet.getAddress();
   }
 }
 ```
@@ -645,7 +593,7 @@ export class TestService {
 Create a [VoidSigner](https://docs.ethers.io/v5/api/signer/ from an address:
 
 ```ts
-import { EthersSigner, InjectSignerProvider, VoidSigner } from 'nestjs-ethers'
+import { EthersSigner, InjectSignerProvider, VoidSigner } from 'nestjs-ethers';
 
 @Injectable()
 export class TestService {
@@ -654,9 +602,11 @@ export class TestService {
     private readonly ethersSigner: EthersSigner,
   ) {}
   async someMethod(): Promise<string> {
-    const wallet: VoidSigner = this.ethersSigner.createVoidSigner('0x012363d61bdc53d0290a0f25e9c89f8257550fb8')
+    const wallet: VoidSigner = this.ethersSigner.createVoidSigner(
+      '0x012363d61bdc53d0290a0f25e9c89f8257550fb8'
+    );
 
-    return wallet.getAddress()
+    return wallet.getAddress();
   }
 }
 ```
@@ -668,8 +618,8 @@ export class TestService {
 Create a `SmartContract` attached to an address:
 
 ```ts
-import { EthersContract, InjectContractProvider, Contract, Network } from 'nestjs-ethers'
-import * as ABI from './utils/ABI.json'
+import { EthersContract, InjectContractProvider, Contract, Network } from 'nestjs-ethers';
+import * as ABI from './utils/ABI.json';
 
 @Injectable()
 class TestService {
@@ -678,9 +628,12 @@ class TestService {
     private readonly ethersContract: EthersContract,
   ) {}
   async someMethod(): Promise<Network> {
-    const contract: Contract = this.ethersContract.create('0x012363d61bdc53d0290a0f25e9c89f8257550fb8', ABI)
+    const contract: Contract = this.ethersContract.create(
+      '0x012363d61bdc53d0290a0f25e9c89f8257550fb8',
+      ABI,
+    );
 
-    return contract.provider.getNetwork()
+    return contract.provider.getNetwork();
   }
 }
 ```
@@ -695,9 +648,9 @@ import {
   InjectSignerProvider,
   Contract,
   Network,
-  Wallet,
-} from 'nestjs-ethers'
-import * as ABI from './utils/ABI.json'
+  Wallet
+} from 'nestjs-ethers';
+import * as ABI from './utils/ABI.json';
 
 @Injectable()
 class TestService {
@@ -709,11 +662,15 @@ class TestService {
   ) {}
   async someMethod(): Promise<Network> {
     const wallet: Wallet = this.ethersSigner.createWallet(
-      '0x4c94faa2c558a998d10ee8b2b9b8eb1fbcb8a6ac5fd085c6f95535604fc1bffb',
-    )
-    const contract: Contract = this.ethersContract.create('0x012363d61bdc53d0290a0f25e9c89f8257550fb8', ABI, wallet)
+      '0x4c94faa2c558a998d10ee8b2b9b8eb1fbcb8a6ac5fd085c6f95535604fc1bffb'
+    );
+    const contract: Contract = this.ethersContract.create(
+      '0x012363d61bdc53d0290a0f25e9c89f8257550fb8',
+      ABI,
+      wallet,
+    );
 
-    return contract.signer.provider.getNetwork()
+    return contract.signer.provider.getNetwork();
   }
 }
 ```
@@ -740,7 +697,7 @@ import {
   RINKEBY_NETWORK,
   MUMBAI_NETWORK,
   BNB_TESTNET_NETWORK,
-} from 'nestjs-ethers'
+} from 'nestjs-ethers';
 
 @Controller('/')
 class TestController {
@@ -811,7 +768,7 @@ import {
   RINKEBY_NETWORK,
   MUMBAI_NETWORK,
   BNB_TESTNET_NETWORK,
-} from 'nestjs-ethers'
+} from 'nestjs-ethers';
 
 @Controller('/')
 class TestController {
@@ -900,53 +857,53 @@ class TestModule {}
 
 ## Testing a class that uses InjectEthersProvider
 
-This package exposes a getEthersToken(token?: string) function that returns a prepared injection token based on the provided context.
+This package exposes a getEthersToken(token?: string) function that returns a prepared injection token based on the provided context. 
 Using this token, you can easily provide a mock implementation of the `BaseProvider` using any of the standard custom provider techniques, including useClass, useValue, and useFactory.
 
 ```ts
-const module: TestingModule = await Test.createTestingModule({
-  providers: [
-    MyService,
-    {
-      provide: getEthersToken(MyService.name),
-      useValue: mockProvider,
-    },
-  ],
-}).compile()
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      MyService,
+      {
+        provide: getEthersToken(MyService.name),
+        useValue: mockProvider,
+      },
+    ],
+  }).compile();
 ```
 
 ## Testing a class that uses InjectContractProvider
 
-This package exposes a getContractToken(token?: string) function that returns a prepared injection token based on the contract provided context.
+This package exposes a getContractToken(token?: string) function that returns a prepared injection token based on the contract provided context. 
 Using this token, you can easily provide a mock implementation of the `ethers.Contract` using any of the standard custom provider techniques, including useClass, useValue, and useFactory.
 
 ```ts
-const module: TestingModule = await Test.createTestingModule({
-  providers: [
-    MyService,
-    {
-      provide: getContractToken(MyService.name),
-      useValue: mockContractProvider,
-    },
-  ],
-}).compile()
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      MyService,
+      {
+        provide: getContractToken(MyService.name),
+        useValue: mockContractProvider,
+      },
+    ],
+  }).compile();
 ```
 
 ## Testing a class that uses InjectSignerProvider
 
-This package exposes a getSignerToken(token?: string) function that returns a prepared injection token based on the signer provided context.
+This package exposes a getSignerToken(token?: string) function that returns a prepared injection token based on the signer provided context. 
 Using this token, you can easily provide a mock implementation of the `ethers.Signer` using any of the standard custom provider techniques, including useClass, useValue, and useFactory.
 
 ```ts
-const module: TestingModule = await Test.createTestingModule({
-  providers: [
-    MyService,
-    {
-      provide: getSignerToken(MyService.name),
-      useValue: mockSignerProvider,
-    },
-  ],
-}).compile()
+  const module: TestingModule = await Test.createTestingModule({
+    providers: [
+      MyService,
+      {
+        provide: getSignerToken(MyService.name),
+        useValue: mockSignerProvider,
+      },
+    ],
+  }).compile();
 ```
 
 ## Migration
@@ -966,22 +923,22 @@ A new more convenient way to inject the `EthersSigner` and `EthersContract` prov
 
 ```ts
 // v0
-import { EthersSigner, WalletSigner } from 'nestjs-ethers'
+import { EthersSigner, WalletSigner } from 'nestjs-ethers';
 
 @Injectable()
 export class TestService {
   constructor(private readonly ethersSigner: EthersSigner) {}
   async someMethod(): Promise<string> {
     const wallet: WalletSigner = this.ethersSigner.createWallet(
-      '0x4c94faa2c558a998d10ee8b2b9b8eb1fbcb8a6ac5fd085c6f95535604fc1bffb',
-    )
+      '0x4c94faa2c558a998d10ee8b2b9b8eb1fbcb8a6ac5fd085c6f95535604fc1bffb'
+    );
 
-    return wallet.getAddress()
+    return wallet.getAddress();
   }
 }
 
 // v1
-import { EthersSigner, InjectSignerProvider, Wallet } from 'nestjs-ethers'
+import { EthersSigner, InjectSignerProvider, Wallet } from 'nestjs-ethers';
 
 @Injectable()
 export class TestService {
@@ -990,11 +947,12 @@ export class TestService {
     private readonly ethersSigner: EthersSigner,
   ) {}
   async someMethod(): Promise<string> {
-    const wallet: Wallet = this.ethersSigner.createWallet(
-      '0x4c94faa2c558a998d10ee8b2b9b8eb1fbcb8a6ac5fd085c6f95535604fc1bffb',
-    )
+    const wallet: Wallet = this.ethersSigner
+    .createWallet(
+      '0x4c94faa2c558a998d10ee8b2b9b8eb1fbcb8a6ac5fd085c6f95535604fc1bffb'
+    );
 
-    return wallet.getAddress()
+    return wallet.getAddress();
   }
 }
 ```
@@ -1003,22 +961,25 @@ export class TestService {
 
 ```ts
 // v0
-import { EthersContract, SmartContract } from 'nestjs-ethers'
-import * as ABI from './utils/ABI.json'
+import { EthersContract, SmartContract } from 'nestjs-ethers';
+import * as ABI from './utils/ABI.json';
 
 @Injectable()
 class TestService {
   constructor(private readonly ethersContract: EthersContract) {}
   async someMethod(): Promise<string> {
-    const contract: SmartContract = this.ethersContract.create('0x012363d61bdc53d0290a0f25e9c89f8257550fb8', ABI)
+    const contract: SmartContract = this.ethersContract.create(
+      '0x012363d61bdc53d0290a0f25e9c89f8257550fb8',
+      ABI,
+    );
 
-    return contract.provider.getNetwork()
+    return contract.provider.getNetwork();
   }
 }
 
 // v1
-import { EthersContract, InjectContractProvider, Contract, Network } from 'nestjs-ethers'
-import * as ABI from './utils/ABI.json'
+import { EthersContract, InjectContractProvider, Contract, Network } from 'nestjs-ethers';
+import * as ABI from './utils/ABI.json';
 
 @Injectable()
 class TestService {
@@ -1027,9 +988,12 @@ class TestService {
     private readonly contract: EthersContract,
   ) {}
   async someMethod(): Promise<Network> {
-    const contract: Contract = this.ethersContract.create('0x012363d61bdc53d0290a0f25e9c89f8257550fb8', ABI)
+    const contract: Contract = this.ethersContract.create(
+      '0x012363d61bdc53d0290a0f25e9c89f8257550fb8',
+      ABI,
+    );
 
-    return contract.provider.getNetwork()
+    return contract.provider.getNetwork();
   }
 }
 ```
@@ -1044,7 +1008,7 @@ Contributions welcome! See [Contributing](CONTRIBUTING.md).
 
 ## Collaborators
 
-- [**Jose Ramirez**](https://github.com/0xslipk)
+* [__Jose Ramirez__](https://github.com/0xslipk)
 
 ## License
 

--- a/__tests__/ethers.custom-rpcs.spec.ts
+++ b/__tests__/ethers.custom-rpcs.spec.ts
@@ -1,4 +1,3 @@
-import { providers as multicall } from '@0xsequence/multicall'
 import {
   AlchemyProvider,
   AnkrProvider,
@@ -22,7 +21,6 @@ import {
   EthereumMoralisProvider,
   getBinanceDefaultProvider,
   getFallbackProvider,
-  getMulticallProvider,
   getNetworkDefaultProvider,
   MoralisProvider,
 } from '../src/ethers.custom-rpcs'
@@ -216,19 +214,6 @@ describe('Ethers Custom RPC', () => {
       ])
 
       expect(provider).toBeInstanceOf(FallbackProvider)
-    })
-  })
-
-  describe('getMulticallProvider', () => {
-    it('should return a instance of MulticallProvider', async () => {
-      const fallbackProvider = await getFallbackProvider([
-        new CloudflareProvider(MAINNET_NETWORK),
-        new InfuraProvider(MAINNET_NETWORK),
-      ])
-
-      const provider = await getMulticallProvider(fallbackProvider)
-
-      expect(provider).toBeInstanceOf(multicall.MulticallProvider)
     })
   })
 

--- a/__tests__/ethers.module.spec.ts
+++ b/__tests__/ethers.module.spec.ts
@@ -1,5 +1,4 @@
 // import { randomBytes } from 'crypto';
-import { providers } from '@0xsequence/multicall'
 import { BigNumber } from '@ethersproject/bignumber'
 import { Network } from '@ethersproject/networks'
 import {
@@ -166,54 +165,6 @@ describe('Ethers Module Initialization', () => {
           await app.close()
         })
 
-        it('should work with alchemy provider with multicall provider', async () => {
-          nock(GOERLI_ALCHEMY_URL)
-            .post(`/${GOERLI_ALCHEMY_API_KEY}`, PROVIDER_GET_GAS_PRICE_BODY)
-            .reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
-
-          @Controller('/')
-          class TestController {
-            constructor(
-              @InjectEthersProvider()
-              private readonly ethersProvider: BaseProvider,
-            ) {}
-            @Get()
-            async get() {
-              const gasPrice: BigNumber = await this.ethersProvider.getGasPrice()
-
-              return { gasPrice: gasPrice.toString() }
-            }
-          }
-          @Module({
-            imports: [
-              EthersModule.forRoot({
-                network: GOERLI_NETWORK,
-                alchemy: GOERLI_ALCHEMY_API_KEY,
-                useDefaultProvider: false,
-                batched: true,
-              }),
-            ],
-            controllers: [TestController],
-          })
-          class TestModule {}
-
-          const app = await NestFactory.create(TestModule, new PlatformAdapter(), NEST_APP_OPTIONS)
-          const server = app.getHttpServer()
-
-          await app.init()
-          await extraWait(PlatformAdapter, app)
-
-          await request(server)
-            .get('/')
-            .expect(200)
-            .expect((res) => {
-              expect(res.body).toBeDefined()
-              expect(res.body).toHaveProperty('gasPrice', '1000000000')
-            })
-
-          await app.close()
-        })
-
         it('should work with pocket provider', async () => {
           nock(GOERLI_POCKET_URL)
             .post(`/${GOERLI_POKT_API_KEY}`, PROVIDER_GET_GAS_PRICE_BODY)
@@ -264,57 +215,6 @@ describe('Ethers Module Initialization', () => {
           await app.close()
         })
 
-        it('should work with pocket provider with multicall provider', async () => {
-          nock(GOERLI_POCKET_URL)
-            .post(`/${GOERLI_POKT_API_KEY}`, PROVIDER_GET_GAS_PRICE_BODY)
-            .reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
-
-          @Controller('/')
-          class TestController {
-            constructor(
-              @InjectEthersProvider()
-              private readonly ethersProvider: BaseProvider,
-            ) {}
-            @Get()
-            async get() {
-              const gasPrice: BigNumber = await this.ethersProvider.getGasPrice()
-
-              return { gasPrice: gasPrice.toString() }
-            }
-          }
-          @Module({
-            imports: [
-              EthersModule.forRoot({
-                network: GOERLI_NETWORK,
-                pocket: {
-                  applicationId: GOERLI_POKT_API_KEY,
-                  applicationSecretKey: GOERLI_POKT_SECRET_KEY,
-                },
-                useDefaultProvider: false,
-                batched: true,
-              }),
-            ],
-            controllers: [TestController],
-          })
-          class TestModule {}
-
-          const app = await NestFactory.create(TestModule, new PlatformAdapter(), NEST_APP_OPTIONS)
-          const server = app.getHttpServer()
-
-          await app.init()
-          await extraWait(PlatformAdapter, app)
-
-          await request(server)
-            .get('/')
-            .expect(200)
-            .expect((res) => {
-              expect(res.body).toBeDefined()
-              expect(res.body).toHaveProperty('gasPrice', '1000000000')
-            })
-
-          await app.close()
-        })
-
         it('should work with ethereum moralis provider', async () => {
           nock(GOERLI_MORALIS_URL).post('', PROVIDER_GET_GAS_PRICE_BODY).reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
 
@@ -337,52 +237,6 @@ describe('Ethers Module Initialization', () => {
                 network: GOERLI_NETWORK,
                 moralis: GOERLI_MORALIS_API_KEY,
                 useDefaultProvider: false,
-              }),
-            ],
-            controllers: [TestController],
-          })
-          class TestModule {}
-
-          const app = await NestFactory.create(TestModule, new PlatformAdapter(), NEST_APP_OPTIONS)
-          const server = app.getHttpServer()
-
-          await app.init()
-          await extraWait(PlatformAdapter, app)
-
-          await request(server)
-            .get('/')
-            .expect(200)
-            .expect((res) => {
-              expect(res.body).toBeDefined()
-              expect(res.body).toHaveProperty('gasPrice', '1000000000')
-            })
-
-          await app.close()
-        })
-
-        it('should work with ethereum moralis provider with multicall provider', async () => {
-          nock(GOERLI_MORALIS_URL).post('', PROVIDER_GET_GAS_PRICE_BODY).reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
-
-          @Controller('/')
-          class TestController {
-            constructor(
-              @InjectEthersProvider()
-              private readonly ethersProvider: BaseProvider,
-            ) {}
-            @Get()
-            async get() {
-              const gasPrice: BigNumber = await this.ethersProvider.getGasPrice()
-
-              return { gasPrice: gasPrice.toString() }
-            }
-          }
-          @Module({
-            imports: [
-              EthersModule.forRoot({
-                network: GOERLI_NETWORK,
-                moralis: GOERLI_MORALIS_API_KEY,
-                useDefaultProvider: false,
-                batched: true,
               }),
             ],
             controllers: [TestController],
@@ -453,54 +307,6 @@ describe('Ethers Module Initialization', () => {
           await app.close()
         })
 
-        it('should work with bsc moralis provider with multicall provider', async () => {
-          nock(BINANCE_TESTNET_MORALIS_URL)
-            .post('', PROVIDER_GET_GAS_PRICE_BODY)
-            .reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
-
-          @Controller('/')
-          class TestController {
-            constructor(
-              @InjectEthersProvider()
-              private readonly ethersProvider: BaseProvider,
-            ) {}
-            @Get()
-            async get() {
-              const gasPrice: BigNumber = await this.ethersProvider.getGasPrice()
-
-              return { gasPrice: gasPrice.toString() }
-            }
-          }
-          @Module({
-            imports: [
-              EthersModule.forRoot({
-                network: BINANCE_TESTNET_NETWORK,
-                moralis: BINANCE_TESTNET_MORALIS_API_KEY,
-                useDefaultProvider: false,
-                batched: true,
-              }),
-            ],
-            controllers: [TestController],
-          })
-          class TestModule {}
-
-          const app = await NestFactory.create(TestModule, new PlatformAdapter(), NEST_APP_OPTIONS)
-          const server = app.getHttpServer()
-
-          await app.init()
-          await extraWait(PlatformAdapter, app)
-
-          await request(server)
-            .get('/')
-            .expect(200)
-            .expect((res) => {
-              expect(res.body).toBeDefined()
-              expect(res.body).toHaveProperty('gasPrice', '1000000000')
-            })
-
-          await app.close()
-        })
-
         it('should work with ankr provider', async () => {
           nock(GOERLI_ANKR_URL).post('', PROVIDER_GET_GAS_PRICE_BODY).reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
 
@@ -523,52 +329,6 @@ describe('Ethers Module Initialization', () => {
                 network: GOERLI_NETWORK,
                 ankr: GOERLI_ANKR_API_KEY,
                 useDefaultProvider: false,
-              }),
-            ],
-            controllers: [TestController],
-          })
-          class TestModule {}
-
-          const app = await NestFactory.create(TestModule, new PlatformAdapter(), NEST_APP_OPTIONS)
-          const server = app.getHttpServer()
-
-          await app.init()
-          await extraWait(PlatformAdapter, app)
-
-          await request(server)
-            .get('/')
-            .expect(200)
-            .expect((res) => {
-              expect(res.body).toBeDefined()
-              expect(res.body).toHaveProperty('gasPrice', '1000000000')
-            })
-
-          await app.close()
-        })
-
-        it('should work with ankr provider with multicall provider', async () => {
-          nock(GOERLI_ANKR_URL).post('', PROVIDER_GET_GAS_PRICE_BODY).reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
-
-          @Controller('/')
-          class TestController {
-            constructor(
-              @InjectEthersProvider()
-              private readonly ethersProvider: BaseProvider,
-            ) {}
-            @Get()
-            async get() {
-              const gasPrice: BigNumber = await this.ethersProvider.getGasPrice()
-
-              return { gasPrice: gasPrice.toString() }
-            }
-          }
-          @Module({
-            imports: [
-              EthersModule.forRoot({
-                network: GOERLI_NETWORK,
-                ankr: GOERLI_ANKR_API_KEY,
-                useDefaultProvider: false,
-                batched: true,
               }),
             ],
             controllers: [TestController],
@@ -619,57 +379,6 @@ describe('Ethers Module Initialization', () => {
                   applicationSecretKey: GOERLI_POKT_SECRET_KEY,
                 },
                 useDefaultProvider: false,
-              }),
-            ],
-            controllers: [TestController],
-          })
-          class TestModule {}
-
-          const app = await NestFactory.create(TestModule, new PlatformAdapter(), NEST_APP_OPTIONS)
-          const server = app.getHttpServer()
-
-          await app.init()
-          await extraWait(PlatformAdapter, app)
-
-          await request(server)
-            .get('/')
-            .expect(200)
-            .expect((res) => {
-              expect(res.body).toBeDefined()
-              expect(res.body).toHaveProperty('gasPrice', '1000000000')
-            })
-
-          await app.close()
-        })
-
-        it('should work with binance pocket provider with multicall provider', async () => {
-          nock(BSC_POCKET_URL)
-            .post(`/${GOERLI_POKT_API_KEY}`, PROVIDER_GET_GAS_PRICE_BODY)
-            .reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
-
-          @Controller('/')
-          class TestController {
-            constructor(
-              @InjectEthersProvider()
-              private readonly ethersProvider: BaseProvider,
-            ) {}
-            @Get()
-            async get() {
-              const gasPrice: BigNumber = await this.ethersProvider.getGasPrice()
-
-              return { gasPrice: gasPrice.toString() }
-            }
-          }
-          @Module({
-            imports: [
-              EthersModule.forRoot({
-                network: BINANCE_NETWORK,
-                pocket: {
-                  applicationId: GOERLI_POKT_API_KEY,
-                  applicationSecretKey: GOERLI_POKT_SECRET_KEY,
-                },
-                useDefaultProvider: false,
-                batched: true,
               }),
             ],
             controllers: [TestController],
@@ -950,56 +659,6 @@ describe('Ethers Module Initialization', () => {
           await app.close()
         })
 
-        it('should work when using multicall provider when using bscscan provider', async () => {
-          nock(TESTNET_BSCSCAN_URL)
-            .get('')
-            .query(ETHERSCAN_GET_GAS_PRICE_QUERY)
-            .reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
-
-          @Controller('/')
-          class TestController {
-            constructor(
-              @InjectEthersProvider()
-              private readonly mutlicallProvider: providers.MulticallProvider,
-            ) {}
-            @Get()
-            async get() {
-              const gasPrice: BigNumber = await this.mutlicallProvider.getGasPrice()
-
-              return { gasPrice: gasPrice.toString() }
-            }
-          }
-
-          @Module({
-            imports: [
-              EthersModule.forRoot({
-                network: BINANCE_TESTNET_NETWORK,
-                bscscan: GOERLI_ETHERSCAN_API_KEY,
-                useDefaultProvider: false,
-                batched: true,
-              }),
-            ],
-            controllers: [TestController],
-          })
-          class TestModule {}
-
-          const app = await NestFactory.create(TestModule, new PlatformAdapter(), NEST_APP_OPTIONS)
-          const server = app.getHttpServer()
-
-          await app.init()
-          await extraWait(PlatformAdapter, app)
-
-          await request(server)
-            .get('/')
-            .expect(200)
-            .expect((res) => {
-              expect(res.body).toBeDefined()
-              expect(res.body).toHaveProperty('gasPrice', '1000000000')
-            })
-
-          await app.close()
-        })
-
         it('should use the default binance providers without community token', async () => {
           nock(TESTNET_BSCSCAN_URL)
             .get('')
@@ -1206,53 +865,6 @@ describe('Ethers Module Initialization', () => {
           await app.close()
         })
 
-        it('should work with one multicall provider', async () => {
-          nock(CUSTOM_BSC_1_URL).post('/', PROVIDER_GET_GAS_PRICE_BODY).reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
-
-          @Controller('/')
-          class TestController {
-            constructor(
-              @InjectEthersProvider()
-              private readonly multicallProvider: providers.MulticallProvider,
-            ) {}
-            @Get()
-            async get() {
-              const gasPrice: BigNumber = await this.multicallProvider.getGasPrice()
-
-              return { gasPrice: gasPrice.toString() }
-            }
-          }
-
-          @Module({
-            imports: [
-              EthersModule.forRoot({
-                network: BINANCE_TESTNET_NETWORK,
-                custom: CUSTOM_BSC_1_URL,
-                useDefaultProvider: false,
-                batched: true,
-              }),
-            ],
-            controllers: [TestController],
-          })
-          class TestModule {}
-
-          const app = await NestFactory.create(TestModule, new PlatformAdapter(), NEST_APP_OPTIONS)
-          const server = app.getHttpServer()
-
-          await app.init()
-          await extraWait(PlatformAdapter, app)
-
-          await request(server)
-            .get('/')
-            .expect(200)
-            .expect((res) => {
-              expect(res.body).toBeDefined()
-              expect(res.body).toHaveProperty('gasPrice', '1000000000')
-            })
-
-          await app.close()
-        })
-
         it('should work with more than one custom provider', async () => {
           nock(CUSTOM_BSC_1_URL)
             .post('/', PROVIDER_GET_GAS_PRICE_BODY)
@@ -1315,69 +927,6 @@ describe('Ethers Module Initialization', () => {
           await app.close()
         })
 
-        it('should when using multicall provider with more than one custom provider', async () => {
-          nock(CUSTOM_BSC_1_URL)
-            .post('/', PROVIDER_GET_GAS_PRICE_BODY)
-            .reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
-            .post('/', PROVIDER_GET_BLOCK_NUMBER_BODY)
-            .reply(200, PROVIDER_GET_BLOCK_NUMBER_RESPONSE)
-
-          nock(CUSTOM_BSC_2_URL)
-            .post('/', PROVIDER_GET_GAS_PRICE_BODY)
-            .reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
-            .post('/', PROVIDER_GET_BLOCK_NUMBER_BODY)
-            .reply(200, PROVIDER_GET_BLOCK_NUMBER_RESPONSE)
-
-          nock(CUSTOM_BSC_3_URL)
-            .post('/', PROVIDER_GET_GAS_PRICE_BODY)
-            .reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
-            .post('/', PROVIDER_GET_BLOCK_NUMBER_BODY)
-            .reply(200, PROVIDER_GET_BLOCK_NUMBER_RESPONSE)
-
-          @Controller('/')
-          class TestController {
-            constructor(
-              @InjectEthersProvider()
-              private readonly multicallProvider: providers.MulticallProvider,
-            ) {}
-            @Get()
-            async get() {
-              const gasPrice: BigNumber = await this.multicallProvider.getGasPrice()
-
-              return { gasPrice: gasPrice.toString() }
-            }
-          }
-
-          @Module({
-            imports: [
-              EthersModule.forRoot({
-                network: BINANCE_TESTNET_NETWORK,
-                custom: [CUSTOM_BSC_1_URL, CUSTOM_BSC_2_URL, CUSTOM_BSC_3_URL],
-                useDefaultProvider: false,
-                batched: true,
-              }),
-            ],
-            controllers: [TestController],
-          })
-          class TestModule {}
-
-          const app = await NestFactory.create(TestModule, new PlatformAdapter(), NEST_APP_OPTIONS)
-          const server = app.getHttpServer()
-
-          await app.init()
-          await extraWait(PlatformAdapter, app)
-
-          await request(server)
-            .get('/')
-            .expect(200)
-            .expect((res) => {
-              expect(res.body).toBeDefined()
-              expect(res.body).toHaveProperty('gasPrice', '1000000000')
-            })
-
-          await app.close()
-        })
-
         it('should work with multiple instances of ethers provider', async () => {
           nock(GOERLI_POCKET_URL)
             .post(`/${GOERLI_POKT_API_KEY}`, PROVIDER_GET_GAS_PRICE_BODY)
@@ -1387,7 +936,6 @@ describe('Ethers Module Initialization', () => {
             .post(`/${GOERLI_ALCHEMY_API_KEY}`, PROVIDER_GET_GAS_PRICE_BODY)
             .reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
 
-          nock(CUSTOM_BSC_1_URL).post('/', PROVIDER_GET_GAS_PRICE_BODY).reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
           nock(CUSTOM_BSC_1_URL).post('/', PROVIDER_GET_GAS_PRICE_BODY).reply(200, PROVIDER_GET_GAS_PRICE_RESPONSE)
 
           @Controller('/')
@@ -1399,21 +947,17 @@ describe('Ethers Module Initialization', () => {
               private readonly alchemyProvider: AlchemyProvider,
               @InjectEthersProvider('bsc')
               private readonly customProvider: StaticJsonRpcProvider,
-              @InjectEthersProvider('multicall')
-              private readonly multicallProvider: providers.MulticallProvider,
             ) {}
             @Get()
             async get() {
               const pocketGasPrice: BigNumber = await this.pocketProvider.getGasPrice()
               const alchemyGasPrice: BigNumber = await this.alchemyProvider.getGasPrice()
               const bscGasPrice: BigNumber = await this.customProvider.getGasPrice()
-              const multicallBscGasPrice: BigNumber = await this.multicallProvider.getGasPrice()
 
               return {
                 pocketGasPrice: pocketGasPrice.toString(),
                 alchemyGasPrice: alchemyGasPrice.toString(),
                 bscGasPrice: bscGasPrice.toString(),
-                multicallBscGasPrice: multicallBscGasPrice.toString(),
               }
             }
           }
@@ -1440,13 +984,6 @@ describe('Ethers Module Initialization', () => {
                 custom: CUSTOM_BSC_1_URL,
                 useDefaultProvider: false,
               }),
-              EthersModule.forRoot({
-                token: 'multicall',
-                network: BINANCE_TESTNET_NETWORK,
-                custom: CUSTOM_BSC_1_URL,
-                useDefaultProvider: false,
-                batched: true,
-              }),
             ],
             controllers: [TestController],
           })
@@ -1469,7 +1006,6 @@ describe('Ethers Module Initialization', () => {
               expect(res.body).toHaveProperty('pocketGasPrice', '1000000000')
               expect(res.body).toHaveProperty('alchemyGasPrice', '1000000000')
               expect(res.body).toHaveProperty('bscGasPrice', '1000000000')
-              expect(res.body).toHaveProperty('multicallBscGasPrice', '1000000000')
             })
 
           await app.close()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.0.3",
       "license": "Apache",
       "dependencies": {
-        "@0xsequence/multicall": "^0.43.26",
         "@ethersproject/abstract-signer": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
         "@ethersproject/bytes": "^5.7.0",
@@ -59,180 +58,6 @@
       },
       "peerDependencies": {
         "@nestjs/common": "^9.2.1"
-      }
-    },
-    "node_modules/@0xsequence/abi": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/abi/-/abi-0.43.26.tgz",
-      "integrity": "sha512-libZgp7wA5DSf4QOmTQb5n1V1cvPXG/qxf8KdGoBEklSZtfbC+G2xcbCGQZOl0qg0j5GwX9B0UtaSXe6IObooQ=="
-    },
-    "node_modules/@0xsequence/api": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/api/-/api-0.43.26.tgz",
-      "integrity": "sha512-+vOEwO/zHUtFai2qloxO5VK0k9t9MrKnOAQUamKLMupDac20GdUjPnaiVfHZ3X16v8yopf2W7Pn9zSMbg4nGBQ=="
-    },
-    "node_modules/@0xsequence/auth": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/auth/-/auth-0.43.26.tgz",
-      "integrity": "sha512-iiGJQf5pg+uAi2nyYxGMbUs3N295CLwg2MnqJbO71/5S/s3eBhSL+lm2hcJvTqh4wRYEmIYsGj2m7t5RATY9ug==",
-      "dependencies": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/api": "^0.43.26",
-        "@0xsequence/config": "^0.43.26",
-        "@0xsequence/ethauth": "^0.8.0",
-        "@0xsequence/indexer": "^0.43.26",
-        "@0xsequence/metadata": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/provider": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26",
-        "@0xsequence/wallet": "^0.43.26"
-      },
-      "peerDependencies": {
-        "ethers": ">=5.5 < 6"
-      }
-    },
-    "node_modules/@0xsequence/config": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/config/-/config-0.43.26.tgz",
-      "integrity": "sha512-Iiip9gPFMOngxEalDgF6f2szJ6Xbme3aAgdW5Xwy4xv+aMPmQH1euEF0/2yD4vGpbG/5aeOR5H0H4zrsuU2/8Q==",
-      "dependencies": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/multicall": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26"
-      },
-      "peerDependencies": {
-        "ethers": ">=5.5 < 6"
-      }
-    },
-    "node_modules/@0xsequence/ethauth": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@0xsequence/ethauth/-/ethauth-0.8.1.tgz",
-      "integrity": "sha512-P21cxRSS+2mDAqFVAJt0lwQFtbObX+Ewlj8DMyDELp81+QbfHFh6LCyu8dTXNdBx6UbmRFOCSBno5Txd50cJPQ==",
-      "dependencies": {
-        "js-base64": "^3.7.2"
-      },
-      "peerDependencies": {
-        "ethers": ">=5.5"
-      }
-    },
-    "node_modules/@0xsequence/guard": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/guard/-/guard-0.43.26.tgz",
-      "integrity": "sha512-C7fRENl+SLQTlrbU3BmxTcG6mB9VApxLLhXscXUEZmWhkGRncEQIPmJaT0RZ2ymchpKGUaKS9w59iyWnejfLzw=="
-    },
-    "node_modules/@0xsequence/indexer": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/indexer/-/indexer-0.43.26.tgz",
-      "integrity": "sha512-mK9WoEvsQjLmVPrkFOdnH2pKCPLyZR6RA14pxgEj/sakmwqRWj9dQIjrNwMWak9Q0XJJ4enlKw/w5xg5HVJzHg=="
-    },
-    "node_modules/@0xsequence/metadata": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/metadata/-/metadata-0.43.26.tgz",
-      "integrity": "sha512-WaD2oInmtFSHHCF+BpQBkBuqBwxcLi7N2uRowhAaQj/vxLJYDz1yIOZS+iWqZnkm5l3ZuidTyfmn+HCw4BIxvw=="
-    },
-    "node_modules/@0xsequence/multicall": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/multicall/-/multicall-0.43.26.tgz",
-      "integrity": "sha512-N4QX5tI2EkFvQS8PR/kVj/RrE9TUFmhqBOv/c4nmZWeuf2X4GS38x55yicnVZmysEX9N5A0URNGa1t0ynGKjdg==",
-      "dependencies": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26"
-      },
-      "peerDependencies": {
-        "ethers": ">=5.5 < 6"
-      }
-    },
-    "node_modules/@0xsequence/network": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/network/-/network-0.43.26.tgz",
-      "integrity": "sha512-e8DEwK5LV+u1TiTBBGHb7/MnTv33+X/0h3aIroMOmHqLjpeDqnJYEvonLYyFNKMX11sse4bvWVC+4PW3pD0k0g==",
-      "dependencies": {
-        "@0xsequence/indexer": "^0.43.26",
-        "@0xsequence/provider": "^0.43.26",
-        "@0xsequence/relayer": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26"
-      },
-      "peerDependencies": {
-        "ethers": ">=5.5 < 6"
-      }
-    },
-    "node_modules/@0xsequence/provider": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/provider/-/provider-0.43.26.tgz",
-      "integrity": "sha512-tpE7BDPNy+4o1KATB1FI25RT9Pj+RdD0wQtpshcrKLuFvWbcdbA/VgD7k0EgZWBnTCMjBc12MZ7pzIrJXxCWHA==",
-      "dependencies": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/auth": "^0.43.26",
-        "@0xsequence/config": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/relayer": "^0.43.26",
-        "@0xsequence/transactions": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26",
-        "@0xsequence/wallet": "^0.43.26",
-        "eventemitter2": "^6.4.5",
-        "webextension-polyfill": "^0.10.0"
-      },
-      "peerDependencies": {
-        "ethers": ">=5.5 < 6"
-      }
-    },
-    "node_modules/@0xsequence/relayer": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/relayer/-/relayer-0.43.26.tgz",
-      "integrity": "sha512-cQ64XokGd7qLsc9tbWShS4AFCo4ikQLb7aitiuPo61GTE8oHaTjckWupBq/cC5zKte0qGVMZFeWI+x6K/yceKA==",
-      "dependencies": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/config": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/transactions": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26"
-      },
-      "peerDependencies": {
-        "ethers": ">=5.5 < 6"
-      }
-    },
-    "node_modules/@0xsequence/transactions": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/transactions/-/transactions-0.43.26.tgz",
-      "integrity": "sha512-b8bG8Y49YjyjnBKUcJV/H28MrNsnPagVkJgCFdTmQEb2XyHXAMqSDiNrRC3EG98H5yy9PT7wXkiaMI4YXaKgtQ==",
-      "dependencies": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/config": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26"
-      },
-      "peerDependencies": {
-        "ethers": ">=5.5 < 6"
-      }
-    },
-    "node_modules/@0xsequence/utils": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/utils/-/utils-0.43.26.tgz",
-      "integrity": "sha512-952LB3mQO4qwA7USdl+75vnkuiiYuCFZ61J49T/jib7Oef/qM9JSlYEDBrZBB6DVtXAEH8zdKLjcewCmc+H2rg==",
-      "dependencies": {
-        "js-base64": "^3.7.2"
-      },
-      "peerDependencies": {
-        "ethers": ">=5.5 < 6"
-      }
-    },
-    "node_modules/@0xsequence/wallet": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/wallet/-/wallet-0.43.26.tgz",
-      "integrity": "sha512-oG/2W0kgtuTosg/5bRxpuooviytd7BgQi3U6x/OyygcKhYpo2CTsLKifU90GANI7aCe71Nj0EDlWZx3UAIrojA==",
-      "dependencies": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/config": "^0.43.26",
-        "@0xsequence/guard": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/relayer": "^0.43.26",
-        "@0xsequence/transactions": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26"
-      },
-      "peerDependencies": {
-        "ethers": ">=5.5 < 6"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1416,30 +1241,6 @@
         "hash.js": "1.1.7"
       }
     },
-    "node_modules/@ethersproject/solidity": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
-      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
     "node_modules/@ethersproject/strings": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
@@ -1484,27 +1285,6 @@
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/rlp": "^5.7.0",
         "@ethersproject/signing-key": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/units": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
-      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/wallet": {
@@ -4507,54 +4287,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
-      }
-    },
     "node_modules/event-stream": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
@@ -4578,11 +4310,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/eventemitter2": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
-      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -6562,11 +6289,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/js-base64": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
-      "integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA=="
     },
     "node_modules/js-sdsl": {
       "version": "4.2.0",
@@ -9173,11 +8895,6 @@
         "makeerror": "1.0.12"
       }
     },
-    "node_modules/webextension-polyfill": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
-      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g=="
-    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -9384,150 +9101,6 @@
     }
   },
   "dependencies": {
-    "@0xsequence/abi": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/abi/-/abi-0.43.26.tgz",
-      "integrity": "sha512-libZgp7wA5DSf4QOmTQb5n1V1cvPXG/qxf8KdGoBEklSZtfbC+G2xcbCGQZOl0qg0j5GwX9B0UtaSXe6IObooQ=="
-    },
-    "@0xsequence/api": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/api/-/api-0.43.26.tgz",
-      "integrity": "sha512-+vOEwO/zHUtFai2qloxO5VK0k9t9MrKnOAQUamKLMupDac20GdUjPnaiVfHZ3X16v8yopf2W7Pn9zSMbg4nGBQ=="
-    },
-    "@0xsequence/auth": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/auth/-/auth-0.43.26.tgz",
-      "integrity": "sha512-iiGJQf5pg+uAi2nyYxGMbUs3N295CLwg2MnqJbO71/5S/s3eBhSL+lm2hcJvTqh4wRYEmIYsGj2m7t5RATY9ug==",
-      "requires": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/api": "^0.43.26",
-        "@0xsequence/config": "^0.43.26",
-        "@0xsequence/ethauth": "^0.8.0",
-        "@0xsequence/indexer": "^0.43.26",
-        "@0xsequence/metadata": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/provider": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26",
-        "@0xsequence/wallet": "^0.43.26"
-      }
-    },
-    "@0xsequence/config": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/config/-/config-0.43.26.tgz",
-      "integrity": "sha512-Iiip9gPFMOngxEalDgF6f2szJ6Xbme3aAgdW5Xwy4xv+aMPmQH1euEF0/2yD4vGpbG/5aeOR5H0H4zrsuU2/8Q==",
-      "requires": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/multicall": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26"
-      }
-    },
-    "@0xsequence/ethauth": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@0xsequence/ethauth/-/ethauth-0.8.1.tgz",
-      "integrity": "sha512-P21cxRSS+2mDAqFVAJt0lwQFtbObX+Ewlj8DMyDELp81+QbfHFh6LCyu8dTXNdBx6UbmRFOCSBno5Txd50cJPQ==",
-      "requires": {
-        "js-base64": "^3.7.2"
-      }
-    },
-    "@0xsequence/guard": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/guard/-/guard-0.43.26.tgz",
-      "integrity": "sha512-C7fRENl+SLQTlrbU3BmxTcG6mB9VApxLLhXscXUEZmWhkGRncEQIPmJaT0RZ2ymchpKGUaKS9w59iyWnejfLzw=="
-    },
-    "@0xsequence/indexer": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/indexer/-/indexer-0.43.26.tgz",
-      "integrity": "sha512-mK9WoEvsQjLmVPrkFOdnH2pKCPLyZR6RA14pxgEj/sakmwqRWj9dQIjrNwMWak9Q0XJJ4enlKw/w5xg5HVJzHg=="
-    },
-    "@0xsequence/metadata": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/metadata/-/metadata-0.43.26.tgz",
-      "integrity": "sha512-WaD2oInmtFSHHCF+BpQBkBuqBwxcLi7N2uRowhAaQj/vxLJYDz1yIOZS+iWqZnkm5l3ZuidTyfmn+HCw4BIxvw=="
-    },
-    "@0xsequence/multicall": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/multicall/-/multicall-0.43.26.tgz",
-      "integrity": "sha512-N4QX5tI2EkFvQS8PR/kVj/RrE9TUFmhqBOv/c4nmZWeuf2X4GS38x55yicnVZmysEX9N5A0URNGa1t0ynGKjdg==",
-      "requires": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26"
-      }
-    },
-    "@0xsequence/network": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/network/-/network-0.43.26.tgz",
-      "integrity": "sha512-e8DEwK5LV+u1TiTBBGHb7/MnTv33+X/0h3aIroMOmHqLjpeDqnJYEvonLYyFNKMX11sse4bvWVC+4PW3pD0k0g==",
-      "requires": {
-        "@0xsequence/indexer": "^0.43.26",
-        "@0xsequence/provider": "^0.43.26",
-        "@0xsequence/relayer": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26"
-      }
-    },
-    "@0xsequence/provider": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/provider/-/provider-0.43.26.tgz",
-      "integrity": "sha512-tpE7BDPNy+4o1KATB1FI25RT9Pj+RdD0wQtpshcrKLuFvWbcdbA/VgD7k0EgZWBnTCMjBc12MZ7pzIrJXxCWHA==",
-      "requires": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/auth": "^0.43.26",
-        "@0xsequence/config": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/relayer": "^0.43.26",
-        "@0xsequence/transactions": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26",
-        "@0xsequence/wallet": "^0.43.26",
-        "eventemitter2": "^6.4.5",
-        "webextension-polyfill": "^0.10.0"
-      }
-    },
-    "@0xsequence/relayer": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/relayer/-/relayer-0.43.26.tgz",
-      "integrity": "sha512-cQ64XokGd7qLsc9tbWShS4AFCo4ikQLb7aitiuPo61GTE8oHaTjckWupBq/cC5zKte0qGVMZFeWI+x6K/yceKA==",
-      "requires": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/config": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/transactions": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26"
-      }
-    },
-    "@0xsequence/transactions": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/transactions/-/transactions-0.43.26.tgz",
-      "integrity": "sha512-b8bG8Y49YjyjnBKUcJV/H28MrNsnPagVkJgCFdTmQEb2XyHXAMqSDiNrRC3EG98H5yy9PT7wXkiaMI4YXaKgtQ==",
-      "requires": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/config": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26"
-      }
-    },
-    "@0xsequence/utils": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/utils/-/utils-0.43.26.tgz",
-      "integrity": "sha512-952LB3mQO4qwA7USdl+75vnkuiiYuCFZ61J49T/jib7Oef/qM9JSlYEDBrZBB6DVtXAEH8zdKLjcewCmc+H2rg==",
-      "requires": {
-        "js-base64": "^3.7.2"
-      }
-    },
-    "@0xsequence/wallet": {
-      "version": "0.43.26",
-      "resolved": "https://registry.npmjs.org/@0xsequence/wallet/-/wallet-0.43.26.tgz",
-      "integrity": "sha512-oG/2W0kgtuTosg/5bRxpuooviytd7BgQi3U6x/OyygcKhYpo2CTsLKifU90GANI7aCe71Nj0EDlWZx3UAIrojA==",
-      "requires": {
-        "@0xsequence/abi": "^0.43.26",
-        "@0xsequence/config": "^0.43.26",
-        "@0xsequence/guard": "^0.43.26",
-        "@0xsequence/network": "^0.43.26",
-        "@0xsequence/relayer": "^0.43.26",
-        "@0xsequence/transactions": "^0.43.26",
-        "@0xsequence/utils": "^0.43.26"
-      }
-    },
     "@ampproject/remapping": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
@@ -10324,20 +9897,6 @@
         "hash.js": "1.1.7"
       }
     },
-    "@ethersproject/solidity": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
-      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-      "peer": true,
-      "requires": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
     "@ethersproject/strings": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
@@ -10362,17 +9921,6 @@
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/rlp": "^5.7.0",
         "@ethersproject/signing-key": "^5.7.0"
-      }
-    },
-    "@ethersproject/units": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
-      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-      "peer": true,
-      "requires": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
       }
     },
     "@ethersproject/wallet": {
@@ -12643,44 +12191,6 @@
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
     },
-    "ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-      "peer": true,
-      "requires": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
-      }
-    },
     "event-stream": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
@@ -12701,11 +12211,6 @@
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "dev": true
-    },
-    "eventemitter2": {
-      "version": "6.4.9",
-      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
-      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg=="
     },
     "events": {
       "version": "3.3.0",
@@ -14204,11 +13709,6 @@
           }
         }
       }
-    },
-    "js-base64": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.5.tgz",
-      "integrity": "sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA=="
     },
     "js-sdsl": {
       "version": "4.2.0",
@@ -16180,11 +15680,6 @@
       "requires": {
         "makeerror": "1.0.12"
       }
-    },
-    "webextension-polyfill": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.10.0.tgz",
-      "integrity": "sha512-c5s35LgVa5tFaHhrZDnr3FpQpjj1BB+RXhLTYUxGqBVN460HkbM8TBtEqdXWbpTKfzwCcjAZVF7zXCYSKtcp9g=="
     },
     "webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "homepage": "https://github.com/blockcoders/nestjs-ethers/blob/main/README.md",
   "bugs": "https://github.com/blockcoders/nestjs-ethers/issues",
   "dependencies": {
-    "@0xsequence/multicall": "^0.43.26",
     "@ethersproject/abstract-signer": "^5.7.0",
     "@ethersproject/bignumber": "^5.7.0",
     "@ethersproject/bytes": "^5.7.0",

--- a/src/ethers.custom-rpcs.ts
+++ b/src/ethers.custom-rpcs.ts
@@ -1,4 +1,3 @@
-import { providers as multicall } from '@0xsequence/multicall'
 import {
   BaseProvider,
   EtherscanProvider,
@@ -206,8 +205,4 @@ export async function getNetworkDefaultProvider(network: Network, options: Provi
   }
 
   return getDefaultProvider(network, options)
-}
-
-export async function getMulticallProvider(provider: FallbackProvider | BaseProvider) {
-  return new multicall.MulticallProvider(provider)
 }

--- a/src/ethers.interface.ts
+++ b/src/ethers.interface.ts
@@ -37,7 +37,6 @@ export interface ProviderOptions {
   ankr?: AnkrProviderOptions | string | undefined
   custom?: ConnectionInfo | string | (ConnectionInfo | string)[] | undefined
   quorum?: number | undefined
-  batched?: boolean | undefined
 }
 
 export interface EthersModuleOptions extends ProviderOptions {

--- a/src/ethers.providers.ts
+++ b/src/ethers.providers.ts
@@ -1,4 +1,3 @@
-import { providers as multicall } from '@0xsequence/multicall'
 import { Logger, LogLevel } from '@ethersproject/logger'
 import {
   Provider as AbstractProvider,
@@ -22,16 +21,13 @@ import {
   BscscanProvider,
   EthereumMoralisProvider,
   getFallbackProvider,
-  getMulticallProvider,
   getNetworkDefaultProvider,
 } from './ethers.custom-rpcs'
 import { EthersModuleOptions, EthersModuleAsyncOptions } from './ethers.interface'
 import { EthersSigner } from './ethers.signer'
 import { getEthersToken, getContractToken, getSignerToken, getNetwork, isBinanceNetwork } from './ethers.utils'
 
-export async function createBaseProvider(
-  options: EthersModuleOptions,
-): Promise<BaseProvider | AbstractProvider | multicall.MulticallProvider> {
+export async function createBaseProvider(options: EthersModuleOptions): Promise<BaseProvider | AbstractProvider> {
   const {
     network = MAINNET_NETWORK,
     quorum = 1,
@@ -47,7 +43,6 @@ export async function createBaseProvider(
     ankr,
     cloudflare = false,
     custom,
-    batched = false,
   } = options
 
   if (disableEthersLogger) {
@@ -111,13 +106,7 @@ export async function createBaseProvider(
       })
     }
 
-    const fallbackProvider = await getFallbackProvider(providers, quorum, waitUntilIsConnected)
-
-    if (batched) {
-      return getMulticallProvider(fallbackProvider)
-    }
-
-    return fallbackProvider
+    return getFallbackProvider(providers, quorum, waitUntilIsConnected)
   }
 
   /**


### PR DESCRIPTION
Reverts blockcoders/nestjs-ethers#148 


[@0xsequence/multicall](https://www.npmjs.com/package/@0xsequence/multicall) Don't support ethers v6. This will be only avaible on [nestjs-ethers@2.1.x](https://www.npmjs.com/package/nestjs-ethers/v/2.1.0)